### PR TITLE
16/05/2025 Filtrado para el listado de comprobantes de pago listo

### DIFF
--- a/database/ComprobantePagoDB.js
+++ b/database/ComprobantePagoDB.js
@@ -47,97 +47,97 @@ class ComprobantePagoDB {
             let whereClauseAdded = false;
 
             // Aplicar filtros dinámicamente
-            if (idEntidadFinanciera !== null) {
+            if (idEntidadFinanciera !== null && idEntidadFinanciera !== "") {
                 query += ` WHERE cp.ID_ENTIDAD_FINANCIERA = ${idEntidadFinanciera}`;
                 whereClauseAdded = true;
             }
 
-            if (fechaInicio !== null && fechaFin !== null) {
+            if (fechaInicio !== null && fechaInicio !== "" && fechaFin !== null && fechaFin !== "") {
                 const fechaCondition = `cp.FEC_PAGO BETWEEN '${fechaInicio}' AND '${fechaFin}'`;
                 query += whereClauseAdded ? ` AND ${fechaCondition}` : ` WHERE ${fechaCondition}`;
                 whereClauseAdded = true;
-            } else if (fechaInicio !== null) {
+            } else if (fechaInicio !== null && fechaInicio !== "") {
                 query += whereClauseAdded ?
                     ` AND cp.FEC_PAGO >= '${fechaInicio}'` :
                     ` WHERE cp.FEC_PAGO >= '${fechaInicio}'`;
                 whereClauseAdded = true;
-            } else if (fechaFin !== null) {
+            } else if (fechaFin !== null && fechaFin !== "") {
                 query += whereClauseAdded ?
                     ` AND cp.FEC_PAGO <= '${fechaFin}'` :
                     ` WHERE cp.FEC_PAGO <= '${fechaFin}'`;
                 whereClauseAdded = true;
             }
 
-            if (estado !== null) {
+            if (estado !== null && estado !== "") {
                 query += whereClauseAdded ?
                     ` AND cp.ESTADO = ${estado}` :
                     ` WHERE cp.ESTADO = ${estado}`;
                 whereClauseAdded = true;
             }
 
-            if (searchValue !== null) {
+            if (searchValue !== null && searchValue !== "") {
                 const searchCondition = `cp.NUM_COMPROBANTE_PAGO LIKE '%${searchValue}%'`;
                 query += whereClauseAdded ? ` AND ${searchCondition}` : ` WHERE ${searchCondition}`;
                 whereClauseAdded = true;
             }
 
-            if (idCuentaBancaria !== null) {
+            if (idCuentaBancaria !== null && idCuentaBancaria !== "") {
                 query += whereClauseAdded ?
                     ` AND cb.ID_CUENTA_BANCARIA = ${idCuentaBancaria}` :
                     ` WHERE cb.ID_CUENTA_BANCARIA = ${idCuentaBancaria}`;
                 whereClauseAdded = true;
             }
 
-            if (pageSize !== null && currentPage !== null) {
+            if (pageSize !== null && pageSize !== "" && currentPage !== null && currentPage !== "") {
                 query += ` ORDER BY cp.ID_COMPROBANTE_PAGO ASC LIMIT ${pageSize} OFFSET ${offset}`;
             }
 
             // Consulta para contar el total de registros
             let countQuery = `
-            SELECT COUNT(*) as total
-            FROM ${this.#table} cp
-            LEFT JOIN sigm_entidad_financiera ef ON cp.ID_ENTIDAD_FINANCIERA = ef.ID_ENTIDAD_FINANCIERA
-            LEFT JOIN sigm_cuenta_bancaria cb ON cp.ID_ENTIDAD_FINANCIERA = cb.ID_ENTIDAD_FINANCIERA
-        `;
+    SELECT COUNT(*) as total
+    FROM ${this.#table} cp
+    LEFT JOIN sigm_entidad_financiera ef ON cp.ID_ENTIDAD_FINANCIERA = ef.ID_ENTIDAD_FINANCIERA
+    LEFT JOIN sigm_cuenta_bancaria cb ON cp.ID_ENTIDAD_FINANCIERA = cb.ID_ENTIDAD_FINANCIERA
+`;
 
             // Aplicar los mismos filtros al conteo
             whereClauseAdded = false;
 
-            if (idEntidadFinanciera !== null) {
+            if (idEntidadFinanciera !== null && idEntidadFinanciera !== "") {
                 countQuery += ` WHERE cp.ID_ENTIDAD_FINANCIERA = ${idEntidadFinanciera}`;
                 whereClauseAdded = true;
             }
 
-            if (fechaInicio !== null && fechaFin !== null) {
+            if (fechaInicio !== null && fechaInicio !== "" && fechaFin !== null && fechaFin !== "") {
                 const fechaCondition = `cp.FEC_PAGO BETWEEN '${fechaInicio}' AND '${fechaFin}'`;
                 countQuery += whereClauseAdded ? ` AND ${fechaCondition}` : ` WHERE ${fechaCondition}`;
                 whereClauseAdded = true;
-            } else if (fechaInicio !== null) {
+            } else if (fechaInicio !== null && fechaInicio !== "") {
                 countQuery += whereClauseAdded ?
                     ` AND cp.FEC_PAGO >= '${fechaInicio}'` :
                     ` WHERE cp.FEC_PAGO >= '${fechaInicio}'`;
                 whereClauseAdded = true;
-            } else if (fechaFin !== null) {
+            } else if (fechaFin !== null && fechaFin !== "") {
                 countQuery += whereClauseAdded ?
                     ` AND cp.FEC_PAGO <= '${fechaFin}'` :
                     ` WHERE cp.FEC_PAGO <= '${fechaFin}'`;
                 whereClauseAdded = true;
             }
 
-            if (estado !== null) {
+            if (estado !== null && estado !== "") {
                 countQuery += whereClauseAdded ?
                     ` AND cp.ESTADO = ${estado}` :
                     ` WHERE cp.ESTADO = ${estado}`;
                 whereClauseAdded = true;
             }
 
-            if (searchValue !== null) {
+            if (searchValue !== null && searchValue !== "") {
                 const searchCondition = `cp.NUM_COMPROBANTE_PAGO LIKE '%${searchValue}%'`;
                 countQuery += whereClauseAdded ? ` AND ${searchCondition}` : ` WHERE ${searchCondition}`;
                 whereClauseAdded = true;
             }
 
-            if (idCuentaBancaria !== null) {
+            if (idCuentaBancaria !== null && idCuentaBancaria !== "") {
                 countQuery += whereClauseAdded ?
                     ` AND cb.ID_CUENTA_BANCARIA = ${idCuentaBancaria}` :
                     ` WHERE cb.ID_CUENTA_BANCARIA = ${idCuentaBancaria}`;
@@ -176,7 +176,12 @@ class ComprobantePagoDB {
                 total: totalRecords,
                 pageSize: pageSize,
                 currentPage: currentPage,
-                totalPages: totalPages
+                totalPages: totalPages,
+                searchValue: searchValue,
+                idEntidadFinanciera: idEntidadFinanciera,
+                fechaInicio: fechaInicio,
+                fechaFin: fechaFin,
+                estado: estado
             };
 
         } catch (error) {

--- a/index.js
+++ b/index.js
@@ -1548,7 +1548,10 @@ ipcMain.on('listar-comprobantes-pago', async (event, { pageSize, currentPage, se
                 currentPage: resultado.currentPage,
                 totalPages: resultado.totalPages,
                 searchValue: resultado.searchValue,
-                idCuentaBancaria: resultado.idCuentaBancaria
+                idEntidadFinanciera: resultado.idEntidadFinanciera,
+                fechaInicio: resultado.fechaInicio,
+                fechaFin: resultado.fechaFin,
+                estado: resultado.estado
             }
         };
 

--- a/public/js/dashboard-js/comprobantes-pago.js
+++ b/public/js/dashboard-js/comprobantes-pago.js
@@ -2,7 +2,7 @@ function cargarComprobantesPagoTabla(pageSize = 10, currentPage = 1, searchValue
     const searchBar = document.getElementById("searchBar");
     if (searchValue !== null && searchBar) searchBar.value = searchValue;
 
-    const tipoFiltro = document.getElementById("tipoFiltro");
+    const tipoFiltro = document.getElementById("estadoFiltro");
     if (estado !== null && tipoFiltro) tipoFiltro.value = estado;
 
     const fechaInicial = document.getElementById("fechaInicial");
@@ -11,9 +11,9 @@ function cargarComprobantesPagoTabla(pageSize = 10, currentPage = 1, searchValue
     const fechaFinal = document.getElementById("fechaFinal");
     if (fechaFin && fechaFinal) fechaFinal.value = fechaFin;
 
-    const pageFiltro = document.getElementById("pageFiltro");
+    const pageFiltro = document.getElementById("selectPageSize");
     if (pageSize && pageFiltro) pageFiltro.value = pageSize;
-
+    cargarCuentasBancariasEnSelect();
     setTimeout(() => {
         // Establecer el valor del select de cuenta bancaria si se proporciona
         if(idCuentaBancaria) document.getElementById("cuentaFiltro").value = idCuentaBancaria;
@@ -27,7 +27,7 @@ function cargarComprobantesPagoTabla(pageSize = 10, currentPage = 1, searchValue
             fechaInicio,
             fechaFin,
             Number(estado) === 2 ? null : estado, // Si es 2, pasamos null para obtener todos
-            idCuentaBancaria,
+            idCuentaBancaria === 0 ? null : idCuentaBancaria, // Si es 0, pasamos null para obtener todos
             (respuesta) => {
                 const tbody = document.getElementById("comprobanteBody");
                 tbody.innerHTML = ""; // Limpiar contenido previo
@@ -57,10 +57,6 @@ function cargarComprobantesPagoTabla(pageSize = 10, currentPage = 1, searchValue
                                     <span class="material-icons">edit</span>
                                     <span class="tooltiptext">Editar comprobante</span>
                                 </button>
-                                <button class="tooltip" value="${comprobante.idComprobantePago}" onclick="verDetallesComprobante(this.value, '/comprobante-view/detalles-comprobante.html', 1)">
-                                    <span class="material-icons">info</span>
-                                    <span class="tooltiptext">Ver detalles</span>
-                                </button>
                                 <button class="tooltip" value="${comprobante.idComprobantePago}" onclick="${comprobante.estadoComprobantePago === 1 ? `actualizarEstadoComprobante(this.value, 0, 'Eliminando comprobante', '¿Está seguro que desea eliminar este comprobante?', 1)` : `actualizarEstadoComprobante(this.value, 1, 'Reactivando comprobante', '¿Está seguro que desea reactivar este comprobante?', 1)`}">
                                     <span class="material-icons">
                                         ${comprobante.estadoComprobantePago === 1 ? 'delete' : 'restore'}
@@ -80,4 +76,28 @@ function cargarComprobantesPagoTabla(pageSize = 10, currentPage = 1, searchValue
             }
         );
     }, 100);
+}
+
+function cargarCuentasBancariasEnSelect() {
+    const selectCuentasBancarias = document.getElementById('cuentaFiltro');
+    selectCuentasBancarias.innerHTML = ""; // Limpiar opciones previas
+    const option = document.createElement('option');
+    option.value = 0;
+    option.textContent = 'Seleccionar cuenta bancaria';
+    selectCuentasBancarias.appendChild(option);
+
+    window.api.obtenerCuentasBancarias(null, null, null, null, null, 1, (respuesta) => {
+        if (!respuesta.success) {
+            console.error('Error al cargar las cuentas financieras.');
+            return;
+        }
+
+        // No eliminamos las opciones existentes, solo agregamos las nuevas
+        respuesta.data.forEach(cuenta => {
+            const option = document.createElement('option');
+            option.value = cuenta.idCuentaBancaria;
+            option.textContent = cuenta.estado ? cuenta.dscBanco + ': ' + cuenta.numCuentaBancaria : `${cuenta.dscBanco + ': ' + cuenta.numCuentaBancaria} (Inactiva)`;
+            selectCuentasBancarias.appendChild(option);
+        });
+    });
 }

--- a/public/js/dashboard-js/cuenta-bancaria.js
+++ b/public/js/dashboard-js/cuenta-bancaria.js
@@ -1,5 +1,5 @@
 function cargarCuentasTabla(pageSize = 10, pageNumber = 1, searchValue = null, idEntidadFinanciera = null, tipoDivisa = null, estado = 1) {
-    cargarEntidadesFinancierasEnSelect()
+    cargarEntidadesFinancierasEnSelect();
     setTimeout(() => {
         if (idEntidadFinanciera !== null) {
             document.getElementById("entidad-financiera-filtro").value = idEntidadFinanciera;
@@ -70,7 +70,11 @@ function mostrarFormCrearCuentaBancaria() {
 
 function cargarEntidadesFinancierasEnSelect() {
     const selectEntidadFinanciera = document.getElementById('entidad-financiera-filtro');
-    //cargarEntidadesFinancierasEnSelect();
+    selectEntidadFinanciera.innerHTML = ''; // Limpiar opciones previas
+    const defaultOption = document.createElement('option');
+    defaultOption.value = '0';
+    defaultOption.textContent = 'Seleccione una entidad financiera';
+    selectEntidadFinanciera.appendChild(defaultOption);
 
     window.api.obtenerEntidadesFinancieras(null, null, null, null, (respuesta) => {
         if (respuesta.error) {

--- a/public/js/dashboard-js/dashboard.js
+++ b/public/js/dashboard-js/dashboard.js
@@ -553,6 +553,9 @@ function filterTable(moduloFiltrar) {
       case 11: // Nuevo caso para Departamentos de Trabajo
       cargarDepartamentosTabla(pageSize, 1, Number(document.getElementById("estado-filtro").value), document.getElementById("search-bar").value);
       break;
+    case 12:
+      cargarComprobantesPagoTabla(pageSize, 1, document.getElementById("searchBar").value, null, document.getElementById("fechaInicial").value, document.getElementById("fechaFinal").value, Number(document.getElementById("estadoFiltro").value), Number(document.getElementById("cuentaFiltro").value));
+      break;
   }
 
 }

--- a/views/comprobantes-pago/comprobantes-pago.html
+++ b/views/comprobantes-pago/comprobantes-pago.html
@@ -6,25 +6,26 @@
         </button>
     </div>
     <div class="search-bar">
-        <input type="text" placeholder="Buscar comprobantes de pago..." id="searchBar">
+        <input type="text" placeholder="Buscar comprobantes de pago..." id="searchBar" onkeypress="filterTable(12)">
     </div>
     <div class="filters">
-        <select id="pageFiltro">
+        <select id="selectPageSize" onchange="filterTable(12)">
+            <option value="5">5 por página</option>
             <option value="10">10 por página</option>
             <option value="25">25 por página</option>
             <option value="50">50 por página</option>
         </select>
-        <select id="tipoFiltro">
+        <select id="estadoFiltro" onchange="filterTable(12)">
             <option value="2">Seleccionar Estado</option>
             <option value="1">Activos</option>
             <option value="0">Inactivos</option>
         </select>
         <div class="date-range">
-            <input type="date" placeholder="Fecha inicial" id="fechaInicial">
+            <input type="date" placeholder="Fecha inicial" id="fechaInicial" onchange="filterTable(12)">
             <span>-</span>
-            <input type="date" placeholder="Fecha final" id="fechaFinal">
+            <input type="date" placeholder="Fecha final" id="fechaFinal" onchange="filterTable(12)">
         </div>
-        <select id="cuentaFiltro">
+        <select id="cuentaFiltro" onchange="filterTable(12)">
             <option value="0">Seleccionar cuenta Bancaria</option>
         </select>
     </div>


### PR DESCRIPTION
Criterios de aceptación:

En el área de administración de comprobantes de pago aparecen los selects para filtrar la lista por cuenta bancaria.

Al seleccionar una cuenta bancaria de la lista se filtra la lista de comprobantes de pago.

Plan de pruebas:

Al activar alguno de los filtros, por factura, cuenta bancaria, estado y valor  de búsqueda se actualiza el listado de los comprobantes de pago.

En caso de no presentar resultados se muestra un mensaje que lo indique.