### PR TITLE
19/05/2025 Creación de comprobante de pago lista

### DIFF
--- a/controllers/ComprobantePagoController.js
+++ b/controllers/ComprobantePagoController.js
@@ -1,14 +1,39 @@
 const ComprobanteDePago = require('../services/ComprobanteDePagoService');
+const ComprobantePago = require('../domain/ComprobantePago');
 
-class ComprobantePagoController{
+class ComprobantePagoController {
     #comprobanteDePagoService;
 
-    constructor(){
+    constructor() {
         this.#comprobanteDePagoService = new ComprobanteDePago();
     }
 
-    async obtenerComprobantesPagos(pageSize, currentPage, searchValue, idEntidadFinanciera, fechaInicio, fechaFin, estado, idCuentaBancaria){
+    async obtenerComprobantesPagos(pageSize, currentPage, searchValue, idEntidadFinanciera, fechaInicio, fechaFin, estado, idCuentaBancaria) {
         return await this.#comprobanteDePagoService.obtenerComprobantesPagos(pageSize, currentPage, searchValue, idEntidadFinanciera, fechaInicio, fechaFin, estado, idCuentaBancaria);
+    }
+
+    async crearComprobantePagoController(datosFormulario) {
+        try {
+            // Crear una nueva instancia de ComprobantePago
+            const comprobantePago = new ComprobantePago();
+
+            // Asignar los valores del JSON al objeto ComprobantePago
+            comprobantePago.getIdEntidadFinanciera().setIdEntidadFinanciera(datosFormulario.cuentaBancaria);
+            comprobantePago.setFechaPago(datosFormulario.fechaPago);
+            comprobantePago.setNumero(datosFormulario.numero);
+            comprobantePago.setMonto(datosFormulario.montoComprobante);
+            comprobantePago.setEstado(true); // Estado por defecto (activo)
+
+            // Llamar al método del servicio para crear el comprobante
+            const resultado = await this.#comprobanteDePagoService.crearComprobantePago(comprobantePago);
+
+            // Retornar el resultado del servicio
+            return resultado;
+
+        } catch (error) {
+            console.error("Error en el controlador al crear el comprobante de pago:", error.message);
+            throw new Error("Error en el controlador al crear el comprobante de pago: " + error.message);
+        }
     }
 }
 

--- a/database/ConectarDB.js
+++ b/database/ConectarDB.js
@@ -9,8 +9,8 @@ class ConectarDB {
 
   constructor() {
     this.#host = "localhost";
-    this.#user = "root";
-    this.#password = "";
+    this.#user = "AdamAG124";
+    this.#password = "adam124";
     this.#database = "dbsigesa";
   }
 

--- a/index.js
+++ b/index.js
@@ -1571,6 +1571,18 @@ ipcMain.on('listar-comprobantes-pago', async (event, { pageSize, currentPage, se
         }
     }
 });
+
+ipcMain.on('crear-comprobante-pago', async (event, comprobantePagoData) => {
+    const comprobantePagoController = new ComprobantePagoController();
+    try {
+        const resultado = await comprobantePagoController.crearComprobantePagoController(comprobantePagoData);
+        event.reply('respuesta-crear-comprobante-pago', resultado);
+    } catch (error) {
+        console.error('Error al crear el comprobante de pago:', error);
+        event.reply('cuenta-bancaria-creada', { success: false, message: error.message });
+    }
+});
+
 ipcMain.on('crear-salida-y-productos', async (event, data) => {
     const { nuevosSalidaProducto, salidaData } = data;
     const controllerSalidaProducto = new SalidaProductoController();

--- a/preload.js
+++ b/preload.js
@@ -248,6 +248,9 @@ contextBridge.exposeInMainWorld('api', {
         ipcRenderer.once('cargar-comprobantes-pago', (event, respuesta) => callback(respuesta));
     },
 
+    crearComprobantePago: (comprobantePagoData) => ipcRenderer.send('crear-comprobante-pago', comprobantePagoData),
+    onRespuestaCrearComprobantePago: (callback) => ipcRenderer.once('respuesta-crear-comprobante-pago', (event, respuesta) => callback(respuesta)),
+
     /* --------------------------------           ------------------------------------------
       --------------------------------  Salida Producto  ------------------------------------------
       --------------------------------           ------------------------------------------ */

--- a/services/ComprobanteDePagoService.js
+++ b/services/ComprobanteDePagoService.js
@@ -10,6 +10,10 @@ class ComprobantePagoService {
     async obtenerComprobantesPagos(pageSize, currentPage, searchValue, idEntidadFinanciera, fechaInicio, fechaFin, estado, idCuentaBancaria){
         return await this.#comprobantePagoDB.listarComprobantesPago(pageSize, currentPage, searchValue, idEntidadFinanciera, fechaInicio, fechaFin, estado, idCuentaBancaria);
     }
+
+    async crearComprobantePago(comprobantePago){
+        return await this.#comprobantePagoDB.crearComprobantePago(comprobantePago);
+    }
 }
 
 module.exports = ComprobantePagoService;

--- a/views/comprobantes-pago/comprobantes-pago.html
+++ b/views/comprobantes-pago/comprobantes-pago.html
@@ -1,7 +1,7 @@
 <div class="main-content">
     <div class="content-header">
         <h1 class="content-title">Administrar Comprobantes de Pago</h1>
-        <button class="add-receipt-btn" title="Agregar Nuevo Comprobante de Pago">
+        <button class="add-receipt-btn" title="Agregar Nuevo Comprobante de Pago" onclick="desplegarFormCrearComprobante()">
             <span class="material-icons">add_box</span>
         </button>
     </div>
@@ -45,6 +45,35 @@
     <div class="pagination">
     </div>
 </div>
+</div>
+
+
+<div id="crearComprobanteModal" class="modal">
+    <div class="modal-content">
+        <span class="close" onclick="cerrarModal('crearComprobanteModal', 'crearComprobanteForm')">&times;</span>
+        <h2 id="modalTitle"></h2>
+        <form id="crearComprobanteForm" class="editar-producto-form">
+            <input type="hidden" id="idProducto">
+
+            <label for="nombre">Cuenta Bancaria:</label>
+            <select id="cuenta">
+                <option value="0">Seleccionar cuenta Bancaria</option>
+            </select>
+
+            <label for="descripcion">Fecha del comprobante de pago:</label>
+            <input type="date" id="fechaPago" required>
+
+            <label for="numero">Número de comprobante:</label>
+            <input type="text" id="numero" min="0" required>
+
+            <label for="montoComprobante">Monto del comprobante:</label>
+            <input type="number" id="montoComprobante" required>
+
+            <p id="errorMessage" style="color: red;"></p>
+
+            <button type="button" class="close-btn" id="buttonModal" onclick="validarFormularioComprobante()">Guardar Cambios</button>
+        </form>
+    </div>
 </div>
 
 <script>


### PR DESCRIPTION
## Criterios de aceptación:

- Existe un botón de creación en el área de administración de comprobantes de pago
- Al clicar el botón se despliega un popup con el formulario para registrar un nuevo comprobante de pago.
- En el formulario además de los inputs para escribir la información aparece un botón de guardar.
- Al clicar el botón se despliega un sweetalert de confirmación con botones de confirmar y cancelar.
- Al clicar en cancelar el sistema no hace nada y solo cierra el sweetalert, y al clicar en confirmar se realiza el registro y aparece un mensaje de exito.
###
## Plan de pruebas:
1. Ingresar al apartado administrativo de comprobantes de pago desde el panel de configuración.
2. Al hacer clic sobre el botón se despliega un popup con el formulario para registrar un nuevo comprobante de pago.
3. Al intentar el envío del formulario sin datos se muestra un mensaje de error.
4. Al enviar el formulario con todos los datos se presenta un mensaje de confirmación sobre el almacenamiento exitoso del comprobante.